### PR TITLE
fixed "execute" which did not print output to console

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -115,6 +115,7 @@ var config = {
 		execute: function (filename) {
 			new SerialComms(port).on('ready', function (comms) {
 				new DeviceManager(comms).executeFile(filename)
+                    .then(console.log)
 					.then(comms.close.bind(comms));
 			});
 		}


### PR DESCRIPTION
I added a ".then(console.log)" so that the output of the lua file gets printed.
