### PR TITLE
Added file.flush after writing "chunks"

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -115,7 +115,6 @@ var config = {
 		execute: function (filename) {
 			new SerialComms(port).on('ready', function (comms) {
 				new DeviceManager(comms).executeFile(filename)
-                    .then(console.log)
 					.then(comms.close.bind(comms));
 			});
 		}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -115,6 +115,7 @@ var config = {
 		execute: function (filename) {
 			new SerialComms(port).on('ready', function (comms) {
 				new DeviceManager(comms).executeFile(filename)
+                    .then(console.log)
 					.then(comms.close.bind(comms));
 			});
 		}

--- a/src/DeviceManager.js
+++ b/src/DeviceManager.js
@@ -100,7 +100,7 @@ DeviceManager.prototype._writeFileChunk = function (chunk) {
 		translate = { '\t': '\\t', '\n': '\\n', '\r': '\\r', '"': '\\"', '\\': '\\\\' };
 
 	chunk = chunk.replace(/[\t\n\r"\\]/g, function (x) { return translate[x]; });
-	command = 'file.write"' + chunk + '"';
+	command = 'file.write"' + chunk + '" file.flush()';
 
 	return this._sendCommand(command);
 };


### PR DESCRIPTION
After having had larger files being corrupted when writing to the esp8266, I found that whole chunks sometimes went missing. This I corrected (and perhaps slowed the file transfer too) by doing a file.flush after every single write.
