### PR TITLE
Add monitor function

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,13 @@ $ esp run "print 'Mechanisms, not policy.'"
 Mechanisms, not policy.
 ```
 
+#### monitor
+Displays the data received from the serial port.
+```
+$ esp monitor
+Displaying output from port /dev/cu.wchusbserial1410.
+Press ^C to stop.
+```
+
 ## License
 MIT
-
-
-

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -137,11 +137,18 @@ var config = {
 				.then(console.log)
 				.then(comms.close.bind(comms));
 		});
-	}
+	},
+
+  monitor: function() {
+		console.log("Displaying output from port " + port + ".");
+		console.log("Press ^C to stop.\n");
+		
+		new SerialComms(port).on('ready', function (comms) {
+			comms.monitor();
+		});  	
+  }
 
 };
-
-
 
 
 function execute (config, args) {

--- a/src/SerialComms.js
+++ b/src/SerialComms.js
@@ -82,5 +82,10 @@ SerialComms.prototype.close = function () {
 };
 
 
+SerialComms.prototype.monitor = function() {
+  this._port.on('data', function(data) {
+     process.stdout.write(data);
+   });
+}
 
 module.exports = SerialComms;


### PR DESCRIPTION
This change adds ability to use this tool to monitor serial port output. If someone is using this tool, chances are they would prefer to use this over starting up an Arduino IDE to use its serial port monitor.
