### PR TITLE
Upgrade serialport to support node 0.10-6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "es6-promise": "^2.0.0",
     "html-minifier": "^0.6.9",
     "luamin": "^0.2.8",
-    "serialport": "^1.4.6",
+    "serialport": "^3.1.2",
     "uglify-js": "^2.4.16"
   }
 }

--- a/src/SerialComms.js
+++ b/src/SerialComms.js
@@ -13,31 +13,25 @@ var SerialPort = require('serialport').SerialPort,
 function SerialComms (port) {
 	this._echoBuffer = '';
 	this._responseBuffer = '';
-	this._port = new SerialPort(port, { 
-		baudrate: 9600,
-		disconnectedCallback: process.exit
-	}, false);
+	this._port = new SerialPort(port, {
+		baudrate: 9600
+	});
 
 	this._initPort();
 }
 
-
 util.inherits(SerialComms, EventEmitter);
-
-
-
 
 SerialComms.prototype._initPort = function () {
 	var _this = this;
-
 	this._port.on('data', function (data) {
-		data = '' + data; 
+		data = '' + data;
 		var len = data.length,
 			response;
 
 		if (data == _this._echoBuffer.substr(0, len)) {
 			_this._echoBuffer = _this._echoBuffer.substr(len);
-		
+
 		} else {
 			_this._responseBuffer += data;
 
@@ -49,19 +43,12 @@ SerialComms.prototype._initPort = function () {
 		}
 	});
 
-	this._port.open(this._handlePortOpen.bind(this));
+	this._port.on('open', function () {
+		_this.emit('ready', _this);
+	});
+
+	this._port.on('disconnect', process.exit);
 };
-
-
-
-
-SerialComms.prototype._handlePortOpen = function (err) {
-	if (err) throw new Error('Failed to open port: ' + err);
-	this.emit('ready', this);
-}
-
-
-
 
 SerialComms.prototype.send = function (data) {
 	if (!this._port) throw new Error('Port not open');


### PR DESCRIPTION
- Listen to open event as the error will automatically throw
- Listen for the disconnect event as the callback is depreciated and only fires on windows.

I don't have the exact hardware around to test, but this should be all you need.

Closes #6 
